### PR TITLE
fix: properly set isEthereal to upgEthereal when card is upgraded

### DIFF
--- a/src/main/java/basicmod/cards/BaseCard.java
+++ b/src/main/java/basicmod/cards/BaseCard.java
@@ -244,6 +244,9 @@ public abstract class BaseCard extends CustomCard {
             if (baseInnate ^ upgInnate)
                 this.isInnate = upgInnate;
 
+            if (baseEthereal ^ upgEthereal)
+                this.isEthereal = upgEthereal;
+
 
             this.initializeDescription();
         }


### PR DESCRIPTION
BaseCard's upgrade method didn't have any logic to update isEthereal if upgEthereal was set different to baseEthereal.