### PR TITLE
Fix implicit profile selection on macOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,20 @@
         </profile>
 
         <profile>
+            <id>linux</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <steam.path>${steam.linux}</steam.path>
+                <sts.path>/common/SlayTheSpire/desktop-1.0.jar</sts.path>
+            </properties>
+        </profile>
+
+        <profile>
             <id>mac</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -214,20 +228,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>linux</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <os>
-                    <family>unix</family>
-                </os>
-            </activation>
-            <properties>
-                <steam.path>${steam.linux}</steam.path>
-                <sts.path>/common/SlayTheSpire/desktop-1.0.jar</sts.path>
-            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Building BasicMod fails on macOS because both the linux and mac profiles are activated:

```
❯ mvn help:active-profiles
...
Active Profiles for Project 'BasicMod:BasicMod:jar:0.0.0':

The following profiles are active:

 - mac (source: BasicMod:BasicMod:0.0.0)
 - linux (source: BasicMod:BasicMod:0.0.0)
...
```

This fails because it uses the `steam.linux` path instead of `steam.mac` (note it looks in the `/Users/colin/.local` folder):

```sh
❯ mvn package
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for BasicMod:BasicMod:jar:0.0.0
[WARNING] 'groupId' contains an expression but should be a constant. @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 38, column 14
[WARNING] 'artifactId' contains an expression but should be a constant. @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 39, column 17
[WARNING] 'dependencies.dependency.systemPath' for com.megacrit.cardcrawl:slaythespire:jar refers to a non-existing file /Users/colin/.local/share/Steam/steamapps/common/SlayTheSpire/desktop-1.0.jar @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 47, column 25
[WARNING] 'dependencies.dependency.systemPath' for com.evacipated.cardcrawl:modthespire:jar refers to a non-existing file /Users/colin/.local/share/Steam/steamapps/workshop/content/646570/1605060445/ModTheSpire.jar @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 54, column 25
[WARNING] 'dependencies.dependency.systemPath' for basemod:basemod:jar refers to a non-existing file /Users/colin/.local/share/Steam/steamapps/workshop/content/646570/1605833019/BaseMod.jar @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 63, column 25
[WARNING] 'dependencies.dependency.systemPath' for com.evacipated.cardcrawl.mod:StSLib:jar refers to a non-existing file /Users/colin/.local/share/Steam/steamapps/workshop/content/646570/1609158507/StSLib.jar @ ${modID}:${modID}:0.0.0, /Users/colin/dev/github.com/colinking/BasicMod/pom.xml, line 70, column 25
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] -------------------------< BasicMod:BasicMod >--------------------------
[INFO] Building Basic Mod 0.0.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.111 s
[INFO] Finished at: 2024-02-01T14:48:53-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project BasicMod: Could not resolve dependencies for project BasicMod:BasicMod:jar:0.0.0: The following artifacts could not be resolved: com.megacrit.cardcrawl:slaythespire:jar:12-18-2022, com.evacipated.cardcrawl:modthespire:jar:3.30.0, basemod:basemod:jar:5.44.0, com.evacipated.cardcrawl.mod:StSLib:jar:2.4.0: Could not find artifact com.megacrit.cardcrawl:slaythespire:jar:12-18-2022 at specified path /Users/colin/.local/share/Steam/steamapps/common/SlayTheSpire/desktop-1.0.jar -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

This fixes it by applying the mac patch after the linux patch. Adding `<name>Linux</name>` from [this SO answer](https://stackoverflow.com/a/44975462/1935727) also fixed the issue, but I can't confirm that works on a Linux system.